### PR TITLE
init: add back TARGET_INIT_VENDOR_LIB for vendor_load_properties

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,32 @@
+name: Sync with upstream
+
+on:
+  workflow_dispatch:
+
+  repository_dispatch:
+    types: [sync_trigger]
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Git
+        run: |
+          git config user.name "Jayant-Deshmukh"
+          git config user.email "jayantdeshmuk008@gmail.com"
+
+      - name: Add upstream remote and rebase
+        run: |
+          git config --global pull.rebase true
+          REPO_NAME="${GITHUB_REPOSITORY##*/}" # Extract the repository name from the GitHub repository context
+          git pull https://github.com/LineageOS/android_${REPO_NAME}.git lineage-22.1
+
+      - name: Push rebased changes to origin
+        run: |
+          git push origin HEAD:fifteen-los --force-with-lease

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -23,10 +23,10 @@ jobs:
 
       - name: Add upstream remote and rebase
         run: |
-          git config --global pull.rebase true
+          git config --global pull.rebase false
           REPO_NAME="${GITHUB_REPOSITORY##*/}" # Extract the repository name from the GitHub repository context
           git pull https://github.com/LineageOS/android_${REPO_NAME}.git lineage-22.1
 
       - name: Push rebased changes to origin
         run: |
-          git push origin HEAD:fifteen-los --force-with-lease
+          git push origin HEAD:fifteen-los

--- a/init/Android.bp
+++ b/init/Android.bp
@@ -123,6 +123,7 @@ libinit_cc_defaults {
         "-DREBOOT_BOOTLOADER_ON_PANIC=0",
         "-DSHUTDOWN_ZERO_TIMEOUT=0",
         "-DWORLD_WRITABLE_KMSG=0",
+        "-DSPOOF_SAFETYNET=1",
         "-Wall",
         "-Werror",
         "-Wextra",
@@ -150,6 +151,8 @@ libinit_cc_defaults {
             cppflags: [
                 "-USHUTDOWN_ZERO_TIMEOUT",
                 "-DSHUTDOWN_ZERO_TIMEOUT=1",
+                "-USPOOF_SAFETYNET",
+                "-DSPOOF_SAFETYNET=0",
             ],
         },
         uml: {
@@ -419,6 +422,7 @@ init_first_stage_cc_defaults {
         "-DSHUTDOWN_ZERO_TIMEOUT=0",
         "-DLOG_UEVENTS=0",
         "-DSEPOLICY_VERSION=30", // TODO(jiyong): externalize the version number
+        "-DSPOOF_SAFETYNET=1",
     ],
 
     product_variables: {
@@ -448,6 +452,8 @@ init_first_stage_cc_defaults {
             cflags: [
                 "-USHUTDOWN_ZERO_TIMEOUT",
                 "-DSHUTDOWN_ZERO_TIMEOUT=1",
+                "-USPOOF_SAFETYNET",
+                "-DSPOOF_SAFETYNET=0",
             ],
         },
     },

--- a/init/Android.bp
+++ b/init/Android.bp
@@ -224,7 +224,6 @@ cc_defaults {
     defaults: [
         "init_defaults",
         "selinux_policy_version",
-        "vendor_init_defaults",
     ],
     srcs: init_common_sources + init_device_sources,
     export_include_dirs: ["."],
@@ -233,7 +232,10 @@ cc_defaults {
     ],
     whole_static_libs: [
         "libcap",
-    ],
+    ] + select(soong_config_variable("libinit", "vendor_init_lib"), {
+        any @ flag_val: [flag_val],
+        default: ["vendor_init"],
+    }),
     header_libs: ["bootimg_headers"],
     proto: {
         type: "lite",

--- a/init/Android.bp
+++ b/init/Android.bp
@@ -283,7 +283,10 @@ cc_defaults {
     name: "init_second_stage_defaults",
     recovery_available: true,
     stem: "init",
-    defaults: ["init_defaults"],
+    defaults: [
+        "init_defaults",
+        "vendor_init_defaults",
+    ],
     srcs: ["main.cpp"],
     symlinks: ["ueventd"],
 }

--- a/init/devices.cpp
+++ b/init/devices.cpp
@@ -42,6 +42,10 @@
 #include "selabel.h"
 #include "util.h"
 
+#ifdef TARGET_CREATE_DEVICE_SYMLINKS
+#include "vendor_init.h"
+#endif
+
 using namespace std::chrono_literals;
 
 using android::base::Basename;
@@ -438,6 +442,10 @@ std::vector<std::string> DeviceHandler::GetBlockDeviceSymlinks(const Uevent& uev
         links.emplace_back("/dev/block/by-name/zoned_device");
         links.emplace_back("/dev/sys/block/by-name/zoned_device");
     }
+
+#ifdef TARGET_CREATE_DEVICE_SYMLINKS
+    vendor_create_device_symlinks(uevent.partition_num, uevent.device_name, links);
+#endif
 
     auto last_slash = uevent.path.rfind('/');
     links.emplace_back(link_path + "/" + uevent.path.substr(last_slash + 1));

--- a/init/property_service.cpp
+++ b/init/property_service.cpp
@@ -1424,6 +1424,18 @@ static void SetSafetyNetProps() {
     InitPropertySet("ro.boot.vbmeta.device_state", "locked");
     InitPropertySet("ro.boot.verifiedbootstate", "green");
     InitPropertySet("ro.boot.veritymode", "enforcing");
+    InitPropertySet("ro.boot.warranty_bit", "0");
+    InitPropertySet("ro.warranty_bit", "0");
+    InitPropertySet("ro.debuggable", "0");
+    InitPropertySet("ro.secure", "1");
+    InitPropertySet("ro.build.type", "user");
+    InitPropertySet("ro.build.keys", "release-keys");
+    InitPropertySet("ro.build.tags", "release-keys");
+    InitPropertySet("ro.system.build.tags", "release-keys");
+    InitPropertySet("ro.vendor.boot.warranty_bit", "0");
+    InitPropertySet("ro.vendor.warranty_bit", "0");
+    InitPropertySet("vendor.boot.vbmeta.device_state", "locked");
+    InitPropertySet("vendor.boot.verifiedbootstate", "green");
 
 }
 

--- a/init/property_service.cpp
+++ b/init/property_service.cpp
@@ -1419,7 +1419,6 @@ static void ProcessBootconfig() {
 }
 
 static void SetSafetyNetProps() {
-
     InitPropertySet("ro.boot.flash.locked", "1");
     InitPropertySet("ro.boot.vbmeta.device_state", "locked");
     InitPropertySet("ro.boot.verifiedbootstate", "green");
@@ -1428,15 +1427,22 @@ static void SetSafetyNetProps() {
     InitPropertySet("ro.warranty_bit", "0");
     InitPropertySet("ro.debuggable", "0");
     InitPropertySet("ro.secure", "1");
+    InitPropertySet("ro.bootimage.build.type", "user");
     InitPropertySet("ro.build.type", "user");
     InitPropertySet("ro.build.keys", "release-keys");
     InitPropertySet("ro.build.tags", "release-keys");
     InitPropertySet("ro.system.build.tags", "release-keys");
+    InitPropertySet("ro.product.build.type", "user");
+    InitPropertySet("ro.odm.build.type", "user");
+    InitPropertySet("ro.system.build.type", "user");
+    InitPropertySet("ro.system_ext.build.type", "user");
+    InitPropertySet("ro.vendor.build.type", "user");
+    InitPropertySet("ro.vendor_dlkm.build.type", "user");
     InitPropertySet("ro.vendor.boot.warranty_bit", "0");
     InitPropertySet("ro.vendor.warranty_bit", "0");
     InitPropertySet("vendor.boot.vbmeta.device_state", "locked");
     InitPropertySet("vendor.boot.verifiedbootstate", "green");
-
+    InitPropertySet("oplusboot.verifiedbootstate", "green");
 }
 
 void PropertyInit() {

--- a/init/property_service.cpp
+++ b/init/property_service.cpp
@@ -1410,6 +1410,15 @@ static void ProcessBootconfig() {
     });
 }
 
+static void SetSafetyNetProps() {
+
+    InitPropertySet("ro.boot.flash.locked", "1");
+    InitPropertySet("ro.boot.vbmeta.device_state", "locked");
+    InitPropertySet("ro.boot.verifiedbootstate", "green");
+    InitPropertySet("ro.boot.veritymode", "enforcing");
+
+}
+
 void PropertyInit() {
     selinux_callback cb;
     cb.func_audit = PropertyAuditCallback;
@@ -1422,6 +1431,14 @@ void PropertyInit() {
     }
     if (!property_info_area.LoadDefaultPath()) {
         LOG(FATAL) << "Failed to load serialized property info file";
+    }
+
+    // Report a valid verified boot chain to make Google SafetyNet integrity
+    // checks pass. This needs to be done before parsing the kernel cmdline as
+    // these properties are read-only and will be set to invalid values with
+    // androidboot cmdline arguments.
+    if (!IsRecoveryMode()) {
+      SetSafetyNetProps();
     }
 
     // If arguments are passed both on the command line and in DT,

--- a/init/property_service.cpp
+++ b/init/property_service.cpp
@@ -1463,8 +1463,10 @@ void PropertyInit() {
     // checks pass. This needs to be done before parsing the kernel cmdline as
     // these properties are read-only and will be set to invalid values with
     // androidboot cmdline arguments.
-    if (!IsRecoveryMode()) {
-      SetSafetyNetProps();
+    if (SPOOF_SAFETYNET) {
+      if (!IsRecoveryMode()) {
+        SetSafetyNetProps();
+      }
     }
 
     // If arguments are passed both on the command line and in DT,

--- a/init/property_service.cpp
+++ b/init/property_service.cpp
@@ -132,6 +132,8 @@ struct PropertyAuditData {
     const char* name;
 };
 
+static bool weaken_prop_override_security = false;
+
 static int PropertyAuditCallback(void* data, security_class_t /*cls*/, char* buf, size_t len) {
     auto* d = reinterpret_cast<PropertyAuditData*>(data);
 
@@ -406,8 +408,8 @@ static std::optional<uint32_t> PropertySet(const std::string& name, const std::s
     } else {
         prop_info* pi = (prop_info*)__system_property_find(name.c_str());
         if (pi != nullptr) {
-            // ro.* properties are actually "write-once".
-            if (StartsWith(name, "ro.")) {
+            // ro.* properties are actually "write-once", unless the system decides to
+            if (StartsWith(name, "ro.") && !weaken_prop_override_security) {
                 *error = "Read-only property was already set";
                 return {PROP_ERROR_READ_ONLY_PROPERTY};
             }
@@ -1242,6 +1244,9 @@ void PropertyLoadBootDefaults() {
         }
     }
 
+    // Weaken property override security during execution of the vendor init extension
+    weaken_prop_override_security = true;
+
     // Update with vendor-specific property runtime overrides
     vendor_load_properties();
 
@@ -1251,6 +1256,9 @@ void PropertyLoadBootDefaults() {
     property_derive_legacy_build_fingerprint();
     property_initialize_ro_cpu_abilist();
     property_initialize_ro_vendor_api_level();
+
+    // Restore the normal property override security after init extension is executed
+    weaken_prop_override_security = false;
 
     update_sys_usb_config();
 }

--- a/init/property_service.cpp
+++ b/init/property_service.cpp
@@ -1514,6 +1514,10 @@ static void HandleInitSocket() {
             }
             InitPropertySet("ro.persistent_properties.ready", "true");
             persistent_properties_loaded = true;
+
+            /* vendor-specific properties
+            */
+            vendor_load_properties();
             break;
         }
         default:

--- a/init/reboot_utils.cpp
+++ b/init/reboot_utils.cpp
@@ -37,7 +37,7 @@
 namespace android {
 namespace init {
 
-static std::string init_fatal_reboot_target = "bootloader";
+static std::string init_fatal_reboot_target = "recovery";
 static bool init_fatal_panic = false;
 
 // this needs to read the /proc/* files directly because it is called before

--- a/init/vendor_init.cpp
+++ b/init/vendor_init.cpp
@@ -1,6 +1,5 @@
 /*
 Copyright (c) 2013, The Linux Foundation. All rights reserved.
-
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
 met:
@@ -13,7 +12,6 @@ met:
     * Neither the name of The Linux Foundation nor the names of its
       contributors may be used to endorse or promote products derived
       from this software without specific prior written permission.
-
 THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
 WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
 MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
@@ -29,9 +27,22 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "vendor_init.h"
 
+namespace android {
+namespace init {
+
 /* init vendor override stubs */
 
 __attribute__ ((weak))
 void vendor_load_properties()
 {
+}
+
+#ifdef TARGET_CREATE_DEVICE_SYMLINKS
+__attribute__ ((weak))
+void vendor_create_device_symlinks(int, std::string, std::vector<std::string>&)
+{
+}
+#endif
+
+}
 }

--- a/init/vendor_init.h
+++ b/init/vendor_init.h
@@ -1,6 +1,5 @@
 /*
 Copyright (c) 2013, The Linux Foundation. All rights reserved.
-
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
 met:
@@ -13,7 +12,6 @@ met:
     * Neither the name of The Linux Foundation nor the names of its
       contributors may be used to endorse or promote products derived
       from this software without specific prior written permission.
-
 THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
 WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
 MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
@@ -29,5 +27,18 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifndef __INIT_VENDOR__H__
 #define __INIT_VENDOR__H__
+
+#include <string>
+
+namespace android {
+namespace init {
+
 extern void vendor_load_properties(void);
+
+#ifdef TARGET_CREATE_DEVICE_SYMLINKS
+extern void vendor_create_device_symlinks(int partNum, std::string partName, std::vector<std::string>& links);
+#endif
+
+}
+}
 #endif /* __INIT_VENDOR__H__ */


### PR DESCRIPTION
squashed:

init: add libinit hook for devices to create device links

let devices react to device uevents e.g. for creating links in /dev/block/by-name/ when there is no partition name available like on raspi with MBR boot device

Change-Id: If657c2608dc5f5363fed4a987f496cd09b56816f